### PR TITLE
Add Ruby 2.6.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 script: bundle exec rspec
 rvm:
+  - 2.6.0
   - 2.5.3
   - 2.4.5
   - 2.3.8


### PR DESCRIPTION
## Pull Request description
Add Ruby 2.6.0 stable (released on 2018-12-25) to the list of Travis tested versions.

## Pull Request checklist

- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [ ] My code is a **new feature** (non-breaking change which adds functionality)
- [ ] My code introduces a **breaking change** (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
