### PR TITLE
Add token generation public method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+[Diff](https://github.com/epistrephein/rarbg/compare/v1.2.0...master)
+
+#### Added
+- Added `token!` public method for standalone token generation.
+
+
 ## 1.2.0 - 2019-01-02
 [RubyGems](https://rubygems.org/gems/rarbg/versions/1.2.0) |
 [Release](https://github.com/epistrephein/rarbg/releases/tag/v1.2.0) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.2.0...master)
 
 #### Added
-- Added `token!` public method for standalone token generation.
+- Added `token!` public method for standalone token generation
+([#3](https://github.com/epistrephein/rarbg/pull/3)).
 
 
 ## 1.2.0 - 2019-01-02

--- a/lib/rarbg.rb
+++ b/lib/rarbg.rb
@@ -7,7 +7,7 @@ require 'rarbg/api'
 # Module namespace shortcut methods.
 module RARBG
   class << self
-    %i[list search].each do |method|
+    %i[list search token!].each do |method|
       define_method(method) do |*args|
         @rarbg ||= RARBG::API.new
         @rarbg.send(method, *args)

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -143,6 +143,18 @@ module RARBG
       call(params)
     end
 
+    # Generate the authentication token.
+    #
+    # @return [String] Return the currently valid token.
+    #
+    # @example Generate the token immediately after object instantiation.
+    #   rarbg = RARBG::API.new
+    #   rarbg.token!
+
+    def token!
+      token?
+    end
+
     private
 
     # Wrap requests for error handling.

--- a/spec/rarbg/token_spec.rb
+++ b/spec/rarbg/token_spec.rb
@@ -51,4 +51,26 @@ RSpec.describe RARBG::API do
       expect { @rarbg.list }.to raise_error(Faraday::ConnectionFailed)
     end
   end
+
+  context 'when forcing the token generation' do
+    before(:example) do
+      stub_token(
+        @token
+      )
+    end
+
+    it 'returns the currently valid token' do
+      expect(@rarbg.token!).to eq(@token)
+    end
+
+    context 'when called from top level namespace' do
+      let(:rarbg_module) { RARBG.clone }
+
+      it 'instantiates an API object' do
+        expect { rarbg_module.token! }
+          .to change { rarbg_module.instance_variable_get(:@rarbg).class }
+          .to(RARBG::API)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Pull Request description
Add a public method to generate the authentication token.

This is useful to mitigate the issue related to rate limit, where performing a `list`/`search` immediately upon instantiation results in a blocking interval related to the fact that endpoint requests are throttled to 1req/2sec.
This is especially bad when the gem is used to serve web content.

Adding the `token!` public method allows to generate the authentication token and perform a `list`/`search` in two separate moments, without downtime.

## Pull Request checklist

- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [x] My code is a **new feature** (non-breaking change which adds functionality)
- [ ] My code introduces a **breaking change** (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
