### PR TITLE
Add Regexps array of ignored error strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.2.0...master)
 
 #### Fixed
-- Return an empty array when endpoint responds with a `Can't find id` error on
-`imdb`, `themoviedb` or `tvdb` search ([#6](https://github.com/epistrephein/rarbg/pull/6)).
+- Return an empty array when endpoint responds with a `Can't find` error on
+`imdb`/`themoviedb`/`tvdb` search ([#6](https://github.com/epistrephein/rarbg/pull/6)).
 - Parse JSON only for responses with `application/json` Content-Type, preventing
 error responses to raise a `ParsingError` ([#4](https://github.com/epistrephein/rarbg/pull/4)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 #### Fixed
 - Return an empty array when endpoint responds with a `Can't find id` error on
-`imdb`, `themoviedb` or `tvdb` search.
+`imdb`, `themoviedb` or `tvdb` search ([#6](https://github.com/epistrephein/rarbg/pull/6)).
 - Parse JSON only for responses with `application/json` Content-Type, preventing
 error responses to raise a `ParsingError` ([#4](https://github.com/epistrephein/rarbg/pull/4)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.2.0...master)
 
 #### Fixed
+- Return an empty array when endpoint responds with a `Can't find id` error on
+`imdb`, `themoviedb` or `tvdb` search.
 - Parse JSON only for responses with `application/json` Content-Type, preventing
 error responses to raise a `ParsingError` ([#4](https://github.com/epistrephein/rarbg/pull/4)).
 

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -38,6 +38,15 @@ module RARBG
     SEARCH_KEYS = %w[string imdb tvdb themoviedb].freeze
     private_constant :SEARCH_KEYS
 
+    # Endpoint error strings to return as no results.
+    IGNORED_ERRORS_REGEXPS = Regexp.union(
+      [
+        /no results found/i,
+        /can'?t find .+? in database/i
+      ]
+    )
+    private_constant :IGNORED_ERRORS_REGEXPS
+
     # Initialize a new instance of `RARBG::API`.
     #
     # @example
@@ -163,7 +172,7 @@ module RARBG
     def call(params)
       response = request(validate(params))
 
-      return [] if response['error'] == 'No results found'
+      return [] if response['error'] =~ IGNORED_ERRORS_REGEXPS
       raise APIError, response['error'] if response.key?('error')
 
       response.fetch('torrent_results', [])

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -39,12 +39,10 @@ module RARBG
     private_constant :SEARCH_KEYS
 
     # Endpoint error strings to return as no results.
-    IGNORED_ERRORS_REGEXPS = Regexp.union(
-      [
-        /no results found/i,
-        /can'?t find .+? in database/i
-      ]
-    )
+    IGNORED_ERRORS_REGEXPS = Regexp.union([
+      /no results found/i,
+      /can'?t find .+? in database/i
+    ])
     private_constant :IGNORED_ERRORS_REGEXPS
 
     # Initialize a new instance of `RARBG::API`.

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -39,11 +39,11 @@ module RARBG
     private_constant :SEARCH_KEYS
 
     # Endpoint error strings to return as no results.
-    IGNORED_ERRORS_REGEXPS = Regexp.union([
+    NO_RESULTS_ERRORS_REGEXPS = Regexp.union([
       /no results found/i,
       /can'?t find .+? in database/i
     ])
-    private_constant :IGNORED_ERRORS_REGEXPS
+    private_constant :NO_RESULTS_ERRORS_REGEXPS
 
     # Initialize a new instance of `RARBG::API`.
     #
@@ -170,7 +170,7 @@ module RARBG
     def call(params)
       response = request(validate(params))
 
-      return [] if response['error'] =~ IGNORED_ERRORS_REGEXPS
+      return [] if response['error'] =~ NO_RESULTS_ERRORS_REGEXPS
       raise APIError, response['error'] if response.key?('error')
 
       response.fetch('torrent_results', [])

--- a/spec/rarbg/search_spec.rb
+++ b/spec/rarbg/search_spec.rb
@@ -53,15 +53,17 @@ RSpec.describe 'RARBG::API#search' do
   end
 
   context 'when search request is unable to find id' do
+    let(:type) { %i[imdb themoviedb tvdb].sample }
+
     before(:example) do
-      stub_list(
+      stub_search(
         @token, {},
-        { error: 'Cant find imdb in database. Are you sure this imdb exists?' }
+        { error: "Cant find #{type} in database. Are you sure this #{type} exists?" }
       )
     end
 
     it 'returns an empty array' do
-      expect(@rarbg.list).to eq([])
+      expect(@rarbg.search(type => '9999999')).to eq([])
     end
   end
 

--- a/spec/rarbg/search_spec.rb
+++ b/spec/rarbg/search_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe 'RARBG::API#search' do
     end
   end
 
+  context 'when search request is unable to find id' do
+    before(:example) do
+      stub_list(
+        @token, {},
+        { error: 'Cant find imdb in database. Are you sure this imdb exists?' }
+      )
+    end
+
+    it 'returns an empty array' do
+      expect(@rarbg.list).to eq([])
+    end
+  end
+
   context 'when search request parameters is not an hash' do
     before(:example) do
       stub_search(

--- a/spec/rarbg/search_spec.rb
+++ b/spec/rarbg/search_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'RARBG::API#search' do
     end
   end
 
-  context 'when search request is unable to find id' do
+  context 'when search request returns id error' do
     let(:type) { %i[imdb themoviedb tvdb].sample }
 
     before(:example) do

--- a/spec/rarbg/search_spec.rb
+++ b/spec/rarbg/search_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'RARBG::API#search' do
     end
   end
 
-  context 'when search request returns id error' do
+  context 'when search request returns an id error' do
     let(:type) { %i[imdb themoviedb tvdb].sample }
 
     before(:example) do


### PR DESCRIPTION
## Pull Request description
Add an array of Regexps for the errors strings returned by the endpoint that can be treated as no results.

This fixes an unintended behavior where the endpoint will return an error string (e.g. `Cant find imdb in database. Are you sure this imdb exists?`) when searching for a imdb, themoviedb or tvdb id that might not exist.
With this change, the request would just return an empty array.

## Pull Request checklist

- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [x] My code is a **new feature** (non-breaking change which adds functionality)
- [ ] My code introduces a **breaking change** (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
