### PR TITLE
Update RuboCop to 0.71

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,4 +2,4 @@ fail_on_violations: true
 
 rubocop:
   config_file: .rubocop.yml
-  version: 0.64.0
+  version: 0.71.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,13 +10,13 @@ Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   EnforcedStyle: consistent
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Metrics/BlockLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fix typos and code style here and there.
 
 #### Changed
-- Bump RuboCop development dependency minimum version to `0.64` and update Hound
-linter version ([#10](https://github.com/epistrephein/rarbg/pull/10)).
+- Bump RuboCop development dependency minimum version to `0.71` and update Hound
+linter version ([#10](https://github.com/epistrephein/rarbg/pull/12)).
 - Allow any Bundler version equal or greater than `1.15` ([#9](https://github.com/epistrephein/rarbg/pull/9))
 but lesser than `3.0` ([#10](https://github.com/epistrephein/rarbg/pull/10)).
 

--- a/rarbg.gemspec
+++ b/rarbg.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
-  spec.add_development_dependency 'rubocop', '~> 0.64', '< 0.68'
+  spec.add_development_dependency 'rubocop', '~> 0.71'
   spec.add_development_dependency 'simplecov', '~> 0.13'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
## Pull Request description
- Use RuboCop `0.71` in development dependencies and in Hound linter.
- Use the new naming of some cops.

## Pull Request checklist

- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [ ] My code is a **new feature** (non-breaking change which adds functionality)
- [ ] My code introduces a **breaking change** (fix or feature that would break existing functionality)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have included the CHANGELOG entry for the changes
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
