### PR TITLE
Update Faraday to v1.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,4 +2,4 @@ fail_on_violations: true
 
 rubocop:
   config_file: .rubocop.yml
-  version: 0.71.0
+  version: 0.75.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-Gemspec/RequiredRubyVersion:
-  Enabled: false
-
 Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: ruby
-sudo: false
 script: bundle exec rspec
 rvm:
   - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.4.0...master)
 
 #### Changed
-- Update Faraday minimum version to 1.0 and Ruby minimum version to 2.3 ([#17](https://github.com/epistrephein/rarbg/pull/17)).
+- Update Faraday to 1.0 and drop faraday_middleware dependency ([#17](https://github.com/epistrephein/rarbg/pull/17)).
+- Update Ruby minimum version to 2.3 ([#17](https://github.com/epistrephein/rarbg/pull/17)).
 - Update version constraints for RuboCop in order to avoid breaking changes ([#16](https://github.com/epistrephein/rarbg/pull/16)).
 - Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.4.0...master)
 
 #### Changed
-- Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
+- Update faraday minimum version to 1.0 and Ruby minimum version to 2.3 ([#17](https://github.com/epistrephein/rarbg/pull/17)).
 - Update version constraints for RuboCop in order to avoid breaking changes ([#16](https://github.com/epistrephein/rarbg/pull/16)).
+- Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
 
 
 ## 1.4.0 - 2019-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.4.0...master)
 
 #### Changed
-- Update faraday minimum version to 1.0 and Ruby minimum version to 2.3 ([#17](https://github.com/epistrephein/rarbg/pull/17)).
+- Update Faraday minimum version to 1.0 and Ruby minimum version to 2.3 ([#17](https://github.com/epistrephein/rarbg/pull/17)).
 - Update version constraints for RuboCop in order to avoid breaking changes ([#16](https://github.com/epistrephein/rarbg/pull/16)).
 - Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem 'rarbg', '~> 1.4'
 
 This gem wraps all API methods available from [RARBG TorrentAPI](https://torrentapi.org/apidocs_v2.txt?&app_id=rarbg-rubygem).
 
-An authentication token is automatically generated on first request, stored with timestamp and renewed every 800 seconds.
+An authentication token is automatically generated on the first request, stored with a timestamp and renewed every 800 seconds.
 
 Rate limit (1req/2s) is automatically enforced.
 

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -85,10 +85,7 @@ module RARBG
     def list(params = {})
       raise ArgumentError, 'Expected params hash' unless params.is_a?(Hash)
 
-      params.update(
-        mode:  'list',
-        token: token?
-      )
+      params.update(mode: 'list', token: token?)
       call(params)
     end
 
@@ -132,10 +129,7 @@ module RARBG
     def search(params = {})
       raise ArgumentError, 'Expected params hash' unless params.is_a?(Hash)
 
-      params.update(
-        mode:  'search',
-        token: token?
-      )
+      params.update(mode: 'search', token: token?)
       call(params)
     end
 
@@ -182,6 +176,7 @@ module RARBG
       normalize.each_pair do |key, proc|
         params[key] = proc.call(params[key]) if params.key?(key)
       end
+
       params
     end
 
@@ -200,6 +195,7 @@ module RARBG
       SEARCH_KEYS.each do |k|
         params["search_#{k}"] = params.delete(k) if params.key?(k)
       end
+
       params
     end
 
@@ -215,17 +211,19 @@ module RARBG
     # Return or renew auth token.
     def token?
       if token.nil? || time >= (token_time.to_f + TOKEN_EXPIRATION)
-        response = request(get_token: 'get_token')
-        @token = response.fetch('token')
+        response    = request(get_token: 'get_token')
+        @token      = response.fetch('token')
         @token_time = time
       end
+
       token
     end
 
     # Perform API request.
     def request(params)
       rate_limit!(RATE_LIMIT)
-      response = conn.get(nil, params)
+
+      response      = conn.get(nil, params)
       @last_request = time
 
       return JSON.parse(response.body) if response.success?

--- a/lib/rarbg/api.rb
+++ b/lib/rarbg/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
+require 'json'
 
 # Main namespace for RARBG.
 module RARBG
@@ -40,8 +40,6 @@ module RARBG
     #   rarbg = RARBG::API.new
     def initialize
       @conn = Faraday.new(url: API_ENDPOINT) do |conn|
-        conn.request  :json
-        conn.response :json, content_type: /\bjson$/
         conn.response :logger if $VERBOSE
         conn.adapter  Faraday.default_adapter
 
@@ -230,7 +228,7 @@ module RARBG
       response = conn.get(nil, params)
       @last_request = time
 
-      return response.body if response.success?
+      return JSON.parse(response.body) if response.success?
 
       raise APIError, "#{response.reason_phrase} (#{response.status})"
     end

--- a/rarbg.gemspec
+++ b/rarbg.gemspec
@@ -29,10 +29,9 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => 'https://github.com/epistrephein/rarbg'
   }
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.3'
 
-  spec.add_runtime_dependency 'faraday', '~> 0.12'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.12'
+  spec.add_runtime_dependency 'faraday', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '>= 1.15', '< 3.0'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
## Pull Request description
- Update the minimum version of `faraday` dependency to v1.0
- Remove `faraday_middleware` dependency and use native JSON lib to parse responses
- Bump minimum Ruby version to 2.3
- Remove `sudo: false` from `.travis.yml` ([Explanation](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration))
- Update RuboCop version of Hound to 0.75 and remove `Gemspec/RequiredRubyVersion` rule
- Minor style fixes

## Pull Request checklist

###### Kind of change
- [ ] My code is a **minor change** (typos, configuration, anything not related to core functionality)
- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [ ] My code is a **new feature** (non-breaking change which adds functionality)
- [x] My code introduces a **breaking change** (fix or feature that would break existing functionality)

###### Style and tests
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

###### Documentation
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

###### Changelog
- [x] I have included the CHANGELOG entry for the changes