### PR TITLE
Update gemspec file to latest style standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.4.0...master)
 
 #### Changed
+- Cleanup gemspec file from unnecessary files and attributes ([#21](https://github.com/epistrephein/rarbg/pull/21)).
 - Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
 - Update version constraints for RuboCop in order to avoid breaking changes ([#16](https://github.com/epistrephein/rarbg/pull/16)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 [Diff](https://github.com/epistrephein/rarbg/compare/v1.4.0...master)
 
 #### Changed
-- Cleanup gemspec file from unnecessary files and attributes ([#21](https://github.com/epistrephein/rarbg/pull/21)).
+- Remove unnecessary files and attributes from gemspec ([#21](https://github.com/epistrephein/rarbg/pull/21)).
 - Update version constraints for Rake, following v13.0 release ([#15](https://github.com/epistrephein/rarbg/pull/15)).
 - Update version constraints for RuboCop in order to avoid breaking changes ([#16](https://github.com/epistrephein/rarbg/pull/16)).
 

--- a/rarbg.gemspec
+++ b/rarbg.gemspec
@@ -15,10 +15,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/epistrephein/rarbg'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['lib/**/*.rb', 'rarbg.gemspec']
-  spec.files        += Dir['README.md', 'CHANGELOG.md', 'LICENSE']
-  spec.require_path  = 'lib'
-
   spec.metadata = {
     'bug_tracker_uri'   => 'https://github.com/epistrephein/rarbg/issues',
     'changelog_uri'     => 'https://github.com/epistrephein/rarbg/blob/master/CHANGELOG.md',
@@ -26,6 +22,10 @@ Gem::Specification.new do |spec|
     'homepage_uri'      => 'https://github.com/epistrephein/rarbg',
     'source_code_uri'   => 'https://github.com/epistrephein/rarbg'
   }
+
+  spec.files         = Dir['lib/**/*.rb', 'rarbg.gemspec']
+  spec.files        += Dir['README.md', 'CHANGELOG.md', 'LICENSE']
+  spec.require_path  = 'lib'
 
   spec.required_ruby_version = '>= 2.0'
 

--- a/rarbg.gemspec
+++ b/rarbg.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|docs)/})
   end
-  spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_path  = 'lib'
 
   spec.metadata = {

--- a/rarbg.gemspec
+++ b/rarbg.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/epistrephein/rarbg'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(spec|docs)/})
-  end
+  spec.files         = Dir['lib/**/*.rb', 'rarbg.gemspec']
+  spec.files        += Dir['README.md', 'CHANGELOG.md', 'LICENSE']
   spec.require_path  = 'lib'
 
   spec.metadata = {


### PR DESCRIPTION
## Pull Request description
- Remove `test_files` attribute since it's [deprecated and no longer used](https://github.com/rubygems/guides/issues/90#issuecomment-49213972).
- Use `Dir[]` instead of `git ls-files` to specify gem files, in order to improve readability and exclude unnecessary files.
- Don't include development files and RSpec tests in the built gem.

## Pull Request checklist

###### Kind of change
- [x] My code is a **minor change** (typo, configuration, anything not related to core functionality)
- [ ] My code is a **bug fix** (non-breaking change which fixes an issue)
- [ ] My code is a **new feature** (non-breaking change which adds functionality)
- [ ] My code introduces a **breaking change** (fix or feature that would break existing functionality)

###### Style and tests
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

###### Documentation
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

###### Changelog
- [x] I have included the CHANGELOG entry for the changes
